### PR TITLE
qastack.com is for sale, but there are contry domain

### DIFF
--- a/uBlacklist.txt
+++ b/uBlacklist.txt
@@ -18,7 +18,7 @@
 *://*.javaer101.com/*
 *://*.programmerstart.com/*
 *://*.programmersought.com/*
-*://*.qastack.com/*
+*://*.qastack.com*
 *://*.roboflow.ai/*
 *://*.stackanswers.net/*
 *://*.stackoom.com/*


### PR DESCRIPTION
there are qastack.com.de, qastack.com.br, etc.